### PR TITLE
Adds optional parameter to ilc_incident_wave to select output space

### DIFF
--- a/matlab_functions/+multem_input/parameters.m
+++ b/matlab_functions/+multem_input/parameters.m
@@ -239,10 +239,13 @@ classdef parameters
       output_area_iy_e(1,1) double = 0.0; 					% y-final in pixel
     end
     methods
-        function out_mt = ilc_incident_wave(obj)
+        function out_mt = ilc_incident_wave(obj, space)
+            if nargin < 2
+                space = 2;
+            end
             prms = obj.toStruct;
             clear ilc_incident_wave;
-            out_mt = ilc_incident_wave(prms.system_conf, prms);
+            out_mt = ilc_incident_wave(prms.system_conf, prms, space);
         end
         function out_mt = ilc_multem(obj)
             prms = obj.toStruct;

--- a/mex_files_multem/ilc_incident_wave.cu
+++ b/mex_files_multem/ilc_incident_wave.cu
@@ -141,7 +141,7 @@ void set_struct_incident_wave(TOutput_Multislice &output_multislice, mxArray *&m
 }
 
 template <class T, mt::eDevice dev>
-void run_incident_wave(mt::System_Configuration &system_conf, const mxArray *mx_input_multislice, mxArray *&mx_output_multislice)
+void run_incident_wave(mt::System_Configuration &system_conf, const mxArray *mx_input_multislice, mxArray *&mx_output_multislice, enum mt::eSpace space)
 {
 	mt::Input_Multislice<T> input_multislice;
 	read_input_multislice(mx_input_multislice, input_multislice);
@@ -157,7 +157,7 @@ void run_incident_wave(mt::System_Configuration &system_conf, const mxArray *mx_
 	mt::Output_Multislice<T> output_multislice;
 	output_multislice.set_input_data(&input_multislice);
 
-	incident_wave(mt::eS_Real, output_multislice);
+	incident_wave(space, output_multislice);
 
 	stream.synchronize();
 
@@ -172,21 +172,30 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
 	auto system_conf = mt::read_system_conf(prhs[0]);
 	int idx_0 = (system_conf.active)?1:0;
+	auto space = mt::eS_Real;
+
+	std::cout << "nrhs = " << nrhs << std::endl;
+	std::cout << "idx_0 = " << idx_0 << std::endl;
+	
+	if (nrhs > idx_0+1)
+	{
+		space = (mt::eSpace)(int)mxGetScalar(prhs[idx_0+1]);
+	}
 
 	if(system_conf.is_float_host())
 	{
-		run_incident_wave<float, mt::e_host>(system_conf, prhs[idx_0], plhs[0]);
+		run_incident_wave<float, mt::e_host>(system_conf, prhs[idx_0], plhs[0], space);
 	}
 	else if(system_conf.is_double_host())
 	{
-		run_incident_wave<double, mt::e_host>(system_conf, prhs[idx_0], plhs[0]);
+		run_incident_wave<double, mt::e_host>(system_conf, prhs[idx_0], plhs[0], space);
 	}
 	else if(system_conf.is_float_device())
 	{
-		run_incident_wave<float, mt::e_device>(system_conf, prhs[idx_0], plhs[0]);
+		run_incident_wave<float, mt::e_device>(system_conf, prhs[idx_0], plhs[0], space);
 	}
 	else if(system_conf.is_double_device())
 	{
-		run_incident_wave<double, mt::e_device>(system_conf, prhs[idx_0], plhs[0]);
+		run_incident_wave<double, mt::e_device>(system_conf, prhs[idx_0], plhs[0], space);
 	}
 }


### PR DESCRIPTION
Fixes Issue #49.

Changes to be committed:
	modified:   matlab_functions/+multem_input/parameters.m
	modified:   mex_files_multem/ilc_incident_wave.cu