### PR TITLE
Update example_MULTEM_STEM_matrix_detector.m

### DIFF
--- a/mex_examples_multem/example_MULTEM_STEM_matrix_detector.m
+++ b/mex_examples_multem/example_MULTEM_STEM_matrix_detector.m
@@ -142,7 +142,7 @@ toc;
 
 figure(2); clf;
 for i=1:length(output_radial_detector.data)
-    suptitle(['Thickness = ' num2str(i)])
+    sgtitle(['Thickness = ' num2str(i)])
     subplot(1, 3, 1);
     imagesc(output_radial_detector.data(i).image_tot(1).image);
     title('Radial Detector');


### PR DESCRIPTION
`suptitle `-> `sgtitle`

`suptitle` is part of the Bioinformatics Toolbox demo. The `sgtitle` function is recommended for MATLAB versions later than R2018b